### PR TITLE
target lowest napi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
           - x64
         node:
           - 20
-          - 24
         include:
           - os: macos-latest
             node: 20
@@ -40,18 +39,6 @@ jobs:
             target: arm64
           - os: windows-11-arm
             node: 20
-            host: arm64
-            target: arm64
-          - os: macos-latest
-            node: 24
-            host: arm64
-            target: arm64
-          - os: ubuntu-22.04-arm
-            node: 24
-            host: arm64
-            target: arm64
-          - os: windows-11-arm
-            node: 24
             host: arm64
             target: arm64
 
@@ -131,16 +118,10 @@ jobs:
         variant:
           - alpine3.20
         include:
-          - target: linux/arm64
-            variant: alpine3.21
-            node: 22
           # musl x64 builds
           - target: linux/amd64
             variant: alpine3.20
             node: 20
-          - target: linux/amd64
-            variant: alpine3.21
-            node: 22
     name: ${{ matrix.variant }} (node=${{ matrix.node }}, target=${{ matrix.target }})
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "install": "node-gyp-build",
-    "prebuild": "prebuildify --target node@20.20.1 --no-napi --strip",
+    "prebuild": "prebuildify --napi --strip",
     "rebuild": "node-gyp rebuild",
     "test": "node test/support/createdb.js && mocha -R spec --timeout 480000"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appthreat/sqlite3",
   "description": "Asynchronous, non-blocking SQLite3 bindings. Modern rewrite of TryGhost/node-sqlite3",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "homepage": "https://github.com/AppThreat/node-sqlite3",
   "author": "Team AppThreat <cloud@appthreat.com>",
   "binary": {
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "install": "node-gyp-build",
-    "prebuild": "prebuildify --napi --strip",
+    "prebuild": "prebuildify --target node@20.20.1 --no-napi --strip",
     "rebuild": "node-gyp rebuild",
     "test": "node test/support/createdb.js && mocha -R spec --timeout 480000"
   },


### PR DESCRIPTION
Based on this [comment](https://github.com/prebuild/prebuildify/pull/91#issuecomment-3220773147), we only need to target the lowest. This is because the filename never includes the napi version like prebuild.